### PR TITLE
Removed ':' from metadata tags

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -391,6 +391,7 @@ EPub.prototype.parseMetadata = function (metadata) {
         var meta = metas[key];
         if (meta['@'] && meta['@'].name) {
             var name = meta['@'].name;
+            name = name.replace(/:/g,'');
             this.metadata[name] = meta['@'].content;
         }
         if (meta['#'] && meta['@'].property) {


### PR DESCRIPTION
Then we can use metadata from calibre library like ‘calibre:series’,
‘calibre:series_index’ or ‘calibre:rating’