### PR TITLE
remove the sequence 'C2A0' which is a utf8 non breaking space.

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -96,7 +96,7 @@ EPub.prototype.parse = function () {
  *  and runs mime type check
  **/
 EPub.prototype.open = function () {
-    try {
+    try {
         this.zip = new ZipFile(this.filename);
     } catch (E) {
         this.emit("error", new Error("Invalid/missing file"));


### PR DESCRIPTION
remove the sequence 'C2A0' which is a utf8 non breaking space. causing tokenization errors in other javascript parsing tools