### PR TITLE
Add default settings to the constructor class

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Or, if you want a pure-JS version (useful if used in a Node-Webkit app for examp
 Where
 
   * **epubfile** is the file path to an EPUB file
-  * **imagewebroot** is the prefix for image URL's. If it's */images/* then the actual URL (inside chapter HTML `<img>` blocks) is going to be */images/IMG_ID/IMG_FILENAME*, `IMG_ID` can be used to fetch the image form the ebook with `getImage`
-  * **chapterwebroot** is the prefix for chapter URL's. If it's */chapter/* then the actual URL (inside chapter HTML `<a>` links) is going to be */chapters/CHAPTER_ID/CHAPTER_FILENAME*, `CHAPTER_ID` can be used to fetch the image form the ebook with `getChapter`
+  * **imagewebroot** is the prefix for image URL's. If it's */images/* then the actual URL (inside chapter HTML `<img>` blocks) is going to be */images/IMG_ID/IMG_FILENAME*, `IMG_ID` can be used to fetch the image form the ebook with `getImage`. Default: `/images/`
+  * **chapterwebroot** is the prefix for chapter URL's. If it's */chapter/* then the actual URL (inside chapter HTML `<a>` links) is going to be */chapters/CHAPTER_ID/CHAPTER_FILENAME*, `CHAPTER_ID` can be used to fetch the image form the ebook with `getChapter`. Default: `/links/`
  
 Before the contents of the ebook can be read, it must be opened (`EPub` is an `EventEmitter`).
 


### PR DESCRIPTION
I noticed in epub.js that the values 'imagewebroot' and 'chapterwebroot' have default values, so I specified them in the documentation.