### PR TITLE
Fix TypeError: (((branch[i].navLabel && branch[i].navLabel.text) || b…

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -522,7 +522,8 @@ EPub.prototype.walkNavMap = function (branch, path, id_list, level) {
 
             var title = '';
             if (branch[i].navLabel && typeof branch[i].navLabel.text == 'string') {
-                title = branch[i].navLabel.text.trim();
+                title = branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel===branch[i].navLabel ? 
+                    '' : (branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel || "").trim();
             }
             var order = Number(branch[i]["@"] && branch[i]["@"].playOrder || 0);
             if (isNaN(order)) {


### PR DESCRIPTION
Fixing "TypeError: (((branch[i].navLabel && branch[i].navLabel.text) || branch[i].navLabel) || "").trim is not a function" error