### PR TITLE
parse the guide

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -81,6 +81,7 @@ class EPub extends EventEmitter {
     
         this.metadata = {};
         this.manifest = {};
+        this.guide = [];
         this.spine    = {toc: false, contents: []};
         this.flow = [];
         this.toc = [];
@@ -290,7 +291,7 @@ class EPub extends EventEmitter {
                 this.parseSpine(rootfile[keys[i]]);
                 break;
             case "guide":
-                //this.parseGuide(rootfile[keys[i]]);
+                this.parseGuide(rootfile[keys[i]]);
                 break;
             }
         }
@@ -424,6 +425,37 @@ class EPub extends EventEmitter {
     
                     this.manifest[manifest.item[i]['@'].id] = element;
     
+                }
+            }
+        }
+    };
+    
+     /**
+     *  EPub#parseGuide() -> undefined
+     *
+     *  Parses "guide" block (locations of the fundamental structural components of the publication)
+     **/
+    parseGuide(guide) {
+        var i, len, path = this.rootFile.split("/"), element, path_str;
+        path.pop();
+        path_str = path.join("/");
+
+        if (guide.reference) {
+            if(!Array.isArray(guide.reference)){
+                guide.reference = [guide.reference];
+            }
+
+            for (i = 0, len = guide.reference.length; i < len; i++) {
+                if (guide.reference[i]['@']) {
+
+                    element = guide.reference[i]['@'];
+
+                    if (element.href && element.href.substr(0, path_str.length)  !=  path_str) {
+                        element.href = path.concat([element.href]).join("/");
+                    }
+
+                    this.guide.push(element);
+
                 }
             }
         }


### PR DESCRIPTION
Parse the [guide block](http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6).
It looks like this might have been an intended feature, but wasn't developed out. 

Adding it has several use cases. One important one is if you want to be able to show the first chapter of actual content or the title page or copyright page, then parsing the guide to find a reference with type "text" or "title-page" or "copyright-page" can be used achieve that. 

