### PR TITLE
Fix crash on empty chapters

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -558,7 +558,7 @@ class EPub extends EventEmitter {
     
                 var title = '';
                 if (branch[i].navLabel && typeof branch[i].navLabel.text == 'string') {
-                    title = branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel===branch[i].navLabel ?
+                    title = branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel===branch[i].navLabel && branch[i].navLabel.text.length > 0  ?
                          (branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel || "").trim() : '';
                 }
                 var order = Number(branch[i]["@"] && branch[i]["@"].playOrder || 0);

--- a/test/test.ts
+++ b/test/test.ts
@@ -20,4 +20,11 @@ mocha.describe('EPub', () => {
 			`/images/`
 		);
 	});
+
+	mocha.it('supports empty chapters', () => {
+		var branch = [{navLabel: { text: '' }}];
+		const epub = new EPub();
+		var res = epub.walkNavMap(branch, [], []);
+		assert.ok(res);
+	});
 });


### PR DESCRIPTION
Previously the parser would crash with the following error:

```
TypeError: (((branch[i].navLabel && branch[i].navLabel.text) || branch[i].navLabel) || "").trim is not a function
      at EPub.walkNavMap (epub.js:562:102)
```

when `navLabel.text` is an empty string, on line 562. I fixed it and added a simple test to show it works (you can remove the fix in epub.js and see the test crash).