### PR TITLE
Fix "Uncaught TypeError: linkparts.shift is not a function" error

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -718,7 +718,11 @@ class EPub extends EventEmitter {
                     return;
                 }
     
-                var str = data.toString("utf-8");
+                var str = "";
+                if (data) {
+                  str = data.toString("utf-8");
+                };
+
     
                 callback(null, str);
     

--- a/epub.js
+++ b/epub.js
@@ -558,7 +558,7 @@ class EPub extends EventEmitter {
     
                 var title = '';
                 if (branch[i].navLabel && typeof branch[i].navLabel.text == 'string') {
-                    title = branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel===branch[i].navLabel ?
+                    title = branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel===branch[i].navLabel && branch[i].navLabel.text.length > 0  ?
                          (branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel || "").trim() : '';
                 }
                 var order = Number(branch[i]["@"] && branch[i]["@"].playOrder || 0);

--- a/epub.js
+++ b/epub.js
@@ -666,8 +666,8 @@ class EPub extends EventEmitter {
     
             // replace links
             str = str.replace(/(\shref\s*=\s*["']?)([^"'\s>]*?)(["'\s>])/g, (function (o, a, b, c) {
-                var linkparts = b && b.split("#"),
-                    link = path.concat([(linkparts.shift() || "")]).join("/").trim(),
+                var linkparts = b && b.split("#");
+                var link = linkparts.length ? path.concat([(linkparts.shift() || "")]).join("/").trim() : '',
                     element;
     
                 for (i = 0, len = keys.length; i < len; i++) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -20,4 +20,11 @@ mocha.describe('EPub', () => {
 			`/images/`
 		);
 	});
+
+	mocha.it('supports empty chapters', () => {
+		var branch = [{navLabel: { text: '' }}];
+		const epub = new EPub();
+		var res = epub.walkNavMap(branch, [], []);
+		assert.ok(res);
+	});
 });


### PR DESCRIPTION
Sorry I was not able to provide a test for this fix as this happened in copyrighted EPUB which I cannot share. And honestly, I am not sure I quite understand what types of links would trigger the crash... :( But this change fixes it (it avoids calling `.shift` when `linkparts` is not an array.