### PR TITLE
feat: replace zipfile with zipread

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -3,9 +3,28 @@ var xml2jsOptions = xml2js.defaults['0.1'];
 var EventEmitter = require('events').EventEmitter;
 
 try {
-    // zipfile is an optional dependency:
-    var ZipFile = require("zipfile").ZipFile;
-} catch (err) {
+    var zipread = require("zipread");
+    var ZipFile = function(filename) {
+        var zip = zipread(filename);
+        this.zip = zip;
+        var files = zip.files;
+
+        files = Object.values(files).filter((file) => {
+            return !file.dir;
+        }).map((file) => {
+            return file.name;
+        });
+
+        this.names = files;
+        this.count = this.names.length;
+    };
+    ZipFile.prototype.readFile = function(name, cb) {
+        this.zip.readFile(name
+            , function(err, buffer) {
+                return cb(null, buffer);
+            });
+    };
+} catch(err) {
     // Mock zipfile using pure-JS adm-zip:
     var AdmZip = require('adm-zip');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,165 +1,211 @@
 {
   "name": "epub",
   "version": "1.3.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/mocha": {
+  "packages": {
+    "": {
+      "name": "epub",
+      "version": "1.3.0",
+      "dependencies": {
+        "adm-zip": "^0.4.11",
+        "xml2js": "^0.4.23",
+        "zipread": "^1.3.3"
+      },
+      "devDependencies": {
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.11.7",
+        "mocha": "^5.2.0",
+        "p-event": "^4",
+        "typescript": "3.6.4"
+      }
+    },
+    "node_modules/@types/mocha": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
       "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
       "dev": true
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "10.17.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.3.tgz",
       "integrity": "sha512-QZ9CjUB3QoA3f2afw3utKlfRPhpmufB7jC2+oDhLWnXqoyx333fhKSQDLQu2EK7OE0a15X67eYiRAaJsHXrpMA==",
       "dev": true
     },
-    "adm-zip": {
+    "node_modules/adm-zip": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
-      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+      "engines": {
+        "node": ">=0.3.0"
+      }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "browser-stdout": {
+    "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "commander": {
+    "node_modules/commander": {
       "version": "2.15.1",
       "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "debug": {
+    "node_modules/debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ms": "2.0.0"
       }
     },
-    "diff": {
+    "node_modules/diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
-    "escape-string-regexp": {
+    "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "growl": {
+    "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
     },
-    "has-flag": {
+    "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "he": {
+    "node_modules/he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
-    "mkdirp": {
+    "node_modules/mkdirp": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
-    "mocha": {
+    "node_modules/mocha": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
       "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "browser-stdout": "1.3.1",
         "commander": "2.15.1",
         "debug": "3.1.0",
@@ -171,1170 +217,135 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
-    "ms": {
+    "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
-      "optional": true
-    },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "p-event": {
+    "node_modules/p-event": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
       "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "p-timeout": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "p-finally": {
+    "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "p-timeout": {
+    "node_modules/p-timeout": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "sax": {
+    "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
       "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "xml2js": {
+    "node_modules/xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
       "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
+      "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
-    "xmlbuilder": {
+    "node_modules/xmlbuilder": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
-    "zipfile": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.11.tgz",
-      "integrity": "sha1-pGwbdnBhOPubz4OJAZPK7GefaF4=",
-      "optional": true,
-      "requires": {
-        "nan": "~2.4.0",
-        "node-pre-gyp": "~0.6.30"
-      },
-      "dependencies": {
-        "node-pre-gyp": {
-          "version": "0.6.32",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "~0.5.1",
-            "nopt": "~3.0.6",
-            "npmlog": "^4.0.1",
-            "rc": "~1.1.6",
-            "request": "^2.79.0",
-            "rimraf": "~2.5.4",
-            "semver": "~5.3.0",
-            "tar": "~2.2.1",
-            "tar-pack": "~3.3.0"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.9",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "npmlog": {
-              "version": "4.0.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.1",
-                "set-blocking": "~2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.0 || ^1.1.13"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "readable-stream": {
-                      "version": "2.2.2",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "buffer-shims": "^1.0.0",
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                      },
-                      "dependencies": {
-                        "buffer-shims": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "gauge": {
-                  "version": "2.7.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "supports-color": "^0.2.0",
-                    "wide-align": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "aproba": {
-                      "version": "1.0.4",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "has-unicode": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "signal-exit": {
-                      "version": "3.0.2",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "number-is-nan": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "0.2.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "wide-align": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "string-width": "^1.0.1"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "rc": {
-              "version": "1.1.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "~0.4.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~1.0.4"
-              },
-              "dependencies": {
-                "deep-extend": {
-                  "version": "0.4.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "bundled": true,
-                  "optional": true
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "strip-json-comments": {
-                  "version": "1.0.4",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "request": {
-              "version": "2.79.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.11.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~2.0.6",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "qs": "~6.3.0",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "~0.4.1",
-                "uuid": "^3.0.0"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "aws4": {
-                  "version": "1.5.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "delayed-stream": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "form-data": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "chalk": "^1.1.1",
-                    "commander": "^2.9.0",
-                    "is-my-json-valid": "^2.12.4",
-                    "pinkie-promise": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "graceful-readlink": ">= 1.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.15.0",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "generate-function": "^2.0.0",
-                        "generate-object-property": "^1.1.0",
-                        "jsonpointer": "^4.0.0",
-                        "xtend": "^4.0.0"
-                      },
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "is-property": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "4.0.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "xtend": {
-                          "version": "4.0.1",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "pinkie": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "boom": "2.x.x"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "jsprim": {
-                      "version": "1.3.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.10.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jodid25519": "^1.0.0",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "^0.14.3"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.1",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.6",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.5",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "mime-types": {
-                  "version": "2.1.13",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "mime-db": "~1.25.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.25.0",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "qs": {
-                  "version": "6.3.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "bundled": true,
-                  "optional": true
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "punycode": "^1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.4.3",
-                  "bundled": true,
-                  "optional": true
-                },
-                "uuid": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.5.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "glob": "^7.0.5"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "7.1.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "fs.realpath": "^1.0.0",
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "^3.0.2",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.3",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "brace-expansion": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.6",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "balanced-match": "^0.4.1",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.4.2",
-                              "bundled": true,
-                              "optional": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "bundled": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "wrappy": "1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "inherits": "~2.0.0"
-                  }
-                },
-                "fstream": {
-                  "version": "1.0.10",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "inherits": "~2.0.0",
-                    "mkdirp": ">=0.5 0",
-                    "rimraf": "2"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "tar-pack": {
-              "version": "3.3.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "debug": "~2.2.0",
-                "fstream": "~1.0.10",
-                "fstream-ignore": "~1.0.5",
-                "once": "~1.3.3",
-                "readable-stream": "~2.1.4",
-                "rimraf": "~2.5.1",
-                "tar": "~2.2.1",
-                "uid-number": "~0.0.6"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.2.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "ms": "0.7.1"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "fstream": {
-                  "version": "1.0.10",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "inherits": "~2.0.0",
-                    "mkdirp": ">=0.5 0",
-                    "rimraf": "2"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "fstream": "^1.0.0",
-                    "inherits": "2",
-                    "minimatch": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.3",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "brace-expansion": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.6",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "balanced-match": "^0.4.1",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.4.2",
-                              "bundled": true,
-                              "optional": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "bundled": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "wrappy": "1"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.1.5",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "buffer-shims": "^1.0.0",
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~1.0.6",
-                    "string_decoder": "~0.10.x",
-                    "util-deprecate": "~1.0.1"
-                  },
-                  "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            }
-          }
-        }
+    "node_modules/zipread": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/zipread/-/zipread-1.3.3.tgz",
+      "integrity": "sha512-r1FKQwTngGmGFY4SvtE6l3s5YFds4bt3GH/1sxucqSNI1XuIEfyTT8lyhy9GFmJ9YXMse3CbL0A4Ios7lpWriA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=0.12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,10 +40,8 @@
   ],
   "dependencies": {
     "adm-zip": "^0.4.11",
-    "xml2js": "^0.4.23"
-  },
-  "optionalDependencies": {
-    "zipfile": "^0.5.11"
+    "xml2js": "^0.4.23",
+    "zipread": "^1.3.3"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",


### PR DESCRIPTION
The zipfile(https://github.com/mapbox/node-zipfile) package currently fails to compile on Node.js 12 and above across Mac/Windows/Linux platforms, and doesn't support Mac ARM or Windows ARM architectures. When using the epub library, requiring zipfile fails, defaulting to adm-zip instead.

zipread uses Node.js's built-in zlib library, offering similar performance to zipfile without requiring compilation, and supports Mac ARM/Windows ARM architectures. Please consider replacing the zipfile package with this alternative.